### PR TITLE
解决‘产’字没有对应好繁体字的问题

### DIFF
--- a/escape.js
+++ b/escape.js
@@ -30,7 +30,7 @@ function translation(str) {
     /*繁体=>简体*/
     if (chHex > 0x4E00 && chHex < 0x9FFF) {
       var index = traChn.indexOf(ch);
-      if (index > 0) {
+      if (index > -1) {
         ch = simChn[index];
         chHex = simChn.charCodeAt(index).toString(16);
         chHex = _.parseInt(chHex, 16);


### PR DESCRIPTION
‘產‘字所对应的坐标是0，这里判断应该为>-1才正确
